### PR TITLE
Adjust handling fee thresholds

### DIFF
--- a/model/cart.php
+++ b/model/cart.php
@@ -170,14 +170,16 @@ if (isset($_POST['reload_cart'])) {
             </tr>';
     }
 
-    // Handling fee logic (same as before)
+    // Handling fee logic updated
     $transferAmount = $total_cart_price;
     $charge = 0;
     if ($transferAmount == 0) {
         $charge = 0;
-    } elseif ($transferAmount < 2500) {
-        $charge = 45;
-    } elseif ($transferAmount >= 2500) {
+    } elseif ($transferAmount <= 4500) {
+        // Flat fee for transactions up to ₦4,500
+        $charge = 100;
+    } else {
+        // Use the previous calculation for amounts above ₦4,500
         $charge += ($transferAmount * 0.014);
         if ($transferAmount >= 2500 && $transferAmount < 5000) {
             $charge += 20;

--- a/model/handle-ps-payment.php
+++ b/model/handle-ps-payment.php
@@ -133,21 +133,29 @@ if (isset($_POST['nivas_ref'])) {
       }
     }
 
-    if ($total_amount < 2500) {
-      $charge = 65;
-    } elseif ($total_amount >= 2500) {
-      // Add 1.5% to the transferAmount
-      $charge += ($total_amount * 0.015);
-
-      // Adjust the charge accordingly
+    if ($total_amount == 0) {
+      $charge = 0;
+    } elseif ($total_amount <= 4500) {
+      // Flat fee for transactions up to ₦4,500
+      $charge = 100;
+    } else {
+      // Preserve the previous calculation for amounts above ₦4,500
       if ($total_amount < 2500) {
-        $charge += 120;
-      } elseif ($total_amount >= 2500 && $total_amount < 5000) {
-        $charge += 125;
-      } elseif ($total_amount >= 5000 && $total_amount < 10000) {
-        $charge += 130;
+        $charge = 65;
       } else {
-        $charge += 135;
+        // Add 1.5% to the transferAmount
+        $charge += ($total_amount * 0.015);
+
+        // Adjust the charge accordingly
+        if ($total_amount < 2500) {
+          $charge += 120;
+        } elseif ($total_amount >= 2500 && $total_amount < 5000) {
+          $charge += 125;
+        } elseif ($total_amount >= 5000 && $total_amount < 10000) {
+          $charge += 130;
+        } else {
+          $charge += 135;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- set a flat ₦100 fee for totals up to ₦4500 in the cart
- use the same flat fee in the Paystack handler

## Testing
- `php -l model/cart.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684164c1b8108328a551fdd264fc3c91