### PR TITLE
Add fallback to school settlement account

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -37,7 +37,10 @@ $event_query = mysqli_query($conn, "SELECT * FROM events WHERE user_id = $user_i
 
 $transaction_query = mysqli_query($conn, "SELECT DISTINCT ref_id, buyer FROM $item_table2 WHERE seller = $user_id ORDER BY `created_at` DESC");
 
-$settlement_query = mysqli_query($conn, "SELECT * FROM settlement_accounts WHERE user_id = $user_id ORDER BY `id` DESC LIMIT 1");
+$settlement_query = mysqli_query($conn, "SELECT * FROM settlement_accounts WHERE school_id = $school_id AND type = 'school' ORDER BY `id` DESC LIMIT 1");
+if (mysqli_num_rows($settlement_query) == 0) {
+  $settlement_query = mysqli_query($conn, "SELECT * FROM settlement_accounts WHERE user_id = $user_id ORDER BY `id` DESC LIMIT 1");
+}
 
 ?>
 <!DOCTYPE html>

--- a/admin/user.php
+++ b/admin/user.php
@@ -8,7 +8,13 @@ if ($_SESSION['nivas_userRole'] == 'student') {
   exit();
 }
 
-$settlement_query = mysqli_query($conn, "SELECT * FROM settlement_accounts WHERE user_id = $user_id ORDER BY `id` DESC LIMIT 1");
+$settlement_query = mysqli_query($conn, "SELECT * FROM settlement_accounts WHERE school_id = $school_id AND type = 'school' ORDER BY `id` DESC LIMIT 1");
+$from_school = false;
+if (mysqli_num_rows($settlement_query) == 0) {
+  $settlement_query = mysqli_query($conn, "SELECT * FROM settlement_accounts WHERE user_id = $user_id ORDER BY `id` DESC LIMIT 1");
+} else {
+  $from_school = true;
+}
 
 $d_icon = 'plus';
 $d_text = 'Add new account';
@@ -19,14 +25,17 @@ $acct_number = '';
 $bank = '1';
 
 if (mysqli_num_rows($settlement_query) == 1) {
-  $d_icon = 'edit';
-  $d_text = 'Edit account';
-  $settlement_id = 1;
   $acct = mysqli_fetch_array($settlement_query);
 
   $acct_name = $acct['acct_name'];
   $acct_number = $acct['acct_number'];
   $bank = $acct['bank'];
+
+  if (!$from_school) {
+    $d_icon = 'edit';
+    $d_text = 'Edit account';
+    $settlement_id = 1;
+  }
 }
 
 $filePath = '../model/all-banks-NG-flw.json';
@@ -200,9 +209,13 @@ $bankName = getBankName($bank, $bankList);
                           <h4 class="card-header pb-3">
                             <div class="d-sm-flex justify-content-between align-items-center">
                               <h4 class="fw-bold">Settlement Account</h4>
-                              <button class="btn btn-primary btn-lg fw-bold text-white mb-0 me-0 view-edit-account" type="button" data-bs-toggle="modal" data-bs-target="#addSettlement"
-                              data-settlement_id="<?php echo $settlement_id ?>" data-acct_name="<?php echo $acct_name ?>" data-acct_number="<?php echo $acct_number ?>" data-bank="<?php echo $bank ?>"><i
-                                  class="mdi mdi-briefcase-<?php echo $d_icon ?>"></i><?php echo $d_text ?></button>
+                              <?php if (!$from_school): ?>
+                                <button class="btn btn-primary btn-lg fw-bold text-white mb-0 me-0 view-edit-account" type="button" data-bs-toggle="modal" data-bs-target="#addSettlement"
+                                data-settlement_id="<?php echo $settlement_id ?>" data-acct_name="<?php echo $acct_name ?>" data-acct_number="<?php echo $acct_number ?>" data-bank="<?php echo $bank ?>"><i
+                                    class="mdi mdi-briefcase-<?php echo $d_icon ?>"></i><?php echo $d_text ?></button>
+                              <?php else: ?>
+                                <span class="badge bg-success">Using school account</span>
+                              <?php endif; ?>
                             </div>
                           </h4>
                           <div class="card-body">

--- a/model/cart.php
+++ b/model/cart.php
@@ -71,7 +71,11 @@ if (isset($_POST['reload_cart'])) {
         $status_c = '';
 
         $seller = $cart_item['user_id'];
-        $seller_code = mysqli_fetch_array(mysqli_query($conn, "SELECT * FROM settlement_accounts WHERE user_id = $seller"))['subaccount_code'];
+        $sett_query = mysqli_query($conn, "SELECT subaccount_code FROM settlement_accounts WHERE school_id = $school_id AND type = 'school' ORDER BY id DESC LIMIT 1");
+        if (mysqli_num_rows($sett_query) == 0) {
+            $sett_query = mysqli_query($conn, "SELECT subaccount_code FROM settlement_accounts WHERE user_id = $seller ORDER BY id DESC LIMIT 1");
+        }
+        $seller_code = mysqli_fetch_array($sett_query)['subaccount_code'];
 
         if ($date > $due_date2 || $status == 'closed') {
             $status = 'disabled';


### PR DESCRIPTION
## Summary
- check for a `type='school'` settlement account that matches the logged in user's school
- use that account if found when deciding if user can add materials/events
- show the school account details on the user profile page
- in the cart system, prefer school settlement account codes for manual sellers
- revert event seller settlement code to use seller's account

## Testing
- ❌ `php -l admin/index.php` (failed to run because `php` was not found)
- ❌ `php -l admin/user.php` (failed to run because `php` was not found)
- ❌ `php -l model/cart.php` (failed to run because `php` was not found)
- ✅ `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853c5c30608832896c44220b46754a6