### PR TITLE
Add watermark on manual export

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -1424,8 +1424,10 @@ if (mysqli_num_rows($settlement_query) == 0) {
 
               // Open a new window with the formatted data
               var exportWindow = window.open("", "_blank");
-              exportWindow.document.write("<html><head><title>Exported Data</title> <style>body {padding: 50px;margin: 0;width: 100%;font-family: sans-serif;box-sizing: border-box;} table{width: 100%} th{text-align: left}</style></head><body>");
-              exportWindow.document.write(heading+table);
+              var logoUrl = window.location.origin + "/assets/images/nivasity-main.png";
+              exportWindow.document.write("<html><head><title>Exported Data</title> <style>body {padding: 50px;margin: 0;width: 100%;font-family: sans-serif;box-sizing: border-box;position: relative;} table{width: 100%} th{text-align: left}.watermark{position: fixed;top: 50%;left: 50%;transform: translate(-50%, -50%);opacity: 0.1;width: 80%;z-index:-1;}</style></head><body>");
+              exportWindow.document.write('<img src="' + logoUrl + '" class="watermark" />');
+              exportWindow.document.write(heading + table);
               exportWindow.document.write("</body></html>");
 
               // Add a print button in the new window


### PR DESCRIPTION
## Summary
- add logo watermark when exporting manual data

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686cf6c914848328b03546f1a0bed615