### PR TITLE
Add faculty selection to manual modals

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -88,6 +88,10 @@ if (mysqli_num_rows($settlement_query) == 0) {
   <link rel="stylesheet" href="../assets/css/dashboard/style.css">
   <!-- endinject -->
   <style>
+    .manual-faculty-select {
+      width: 100%;
+    }
+
     .manual-faculty-select:focus {
       border-color: var(--bs-primary, #FF9100);
       box-shadow: 0 0 0 0.25rem rgba(255, 145, 0, 0.25);

--- a/admin/index.php
+++ b/admin/index.php
@@ -806,6 +806,7 @@ if (mysqli_num_rows($settlement_query) == 0) {
                                 <option value="<?php echo (int) $faculty_id; ?>"><?php echo htmlspecialchars($faculty_name); ?></option>
                               <?php endforeach; ?>
                             </select>
+                            <p class="form-text mt-2">This doesn't mean your faculty/college, but where the material is being collected from</p>
                           </div>
                         </div>
                         <div class="modal-footer">

--- a/admin/index.php
+++ b/admin/index.php
@@ -87,6 +87,13 @@ if (mysqli_num_rows($settlement_query) == 0) {
   <!-- inject:css -->
   <link rel="stylesheet" href="../assets/css/dashboard/style.css">
   <!-- endinject -->
+  <style>
+    .manual-faculty-select:focus {
+      border-color: var(--bs-primary, #FF9100);
+      box-shadow: 0 0 0 0.25rem rgba(255, 145, 0, 0.25);
+      outline: 0;
+    }
+  </style>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.4.0/jspdf.umd.min.js"></script>
   
   <!-- main js -->
@@ -748,15 +755,6 @@ if (mysqli_num_rows($settlement_query) == 0) {
                             <input type="text" name="title" class="form-control form-control-lg w-100" required="">
                             <label class="form-label" for="title">Material Title</label>
                           </div>
-                          <div class="form-group mb-4">
-                            <label class="form-check-label mb-0" for="manual_faculty">Associated Faculty</label><br />
-                            <select id="manual_faculty" name="faculty" class="form-select form-select-lg" <?php echo empty($faculties) ? 'disabled' : 'required'; ?>>
-                              <option value="" selected disabled><?php echo empty($faculties) ? 'No faculties available' : 'Select faculty'; ?></option>
-                              <?php foreach ($faculties as $faculty_id => $faculty_name): ?>
-                                <option value="<?php echo (int) $faculty_id; ?>"><?php echo htmlspecialchars($faculty_name); ?></option>
-                              <?php endforeach; ?>
-                            </select>
-                          </div>
                           <div class="row">
                             <div class="col-12">
                               <div class="form-check form-switch">
@@ -794,6 +792,16 @@ if (mysqli_num_rows($settlement_query) == 0) {
                                 <label class="form-label" for="due_date">Due Date</label>
                               </div>
                             </div>
+                          </div>
+                          <div class="form-group mb-0">
+                            <label class="form-label" for="manual_faculty">Associated Faculty</label>
+                            <select id="manual_faculty" name="faculty"
+                              class="form-control form-control-lg manual-faculty-select" <?php echo empty($faculties) ? 'disabled' : 'required'; ?>>
+                              <option value="" selected disabled><?php echo empty($faculties) ? 'No faculties available' : 'Select faculty'; ?></option>
+                              <?php foreach ($faculties as $faculty_id => $faculty_name): ?>
+                                <option value="<?php echo (int) $faculty_id; ?>"><?php echo htmlspecialchars($faculty_name); ?></option>
+                              <?php endforeach; ?>
+                            </select>
                           </div>
                         </div>
                         <div class="modal-footer">

--- a/admin/model/manuals.php
+++ b/admin/model/manuals.php
@@ -51,6 +51,8 @@ if (isset($_POST['close_manual'])) {
   $price = mysqli_real_escape_string($conn, $_POST['price']);
   $quantity = mysqli_real_escape_string($conn, $_POST['quantity']);
   $due_date = mysqli_real_escape_string($conn, $_POST['due_date']);
+  $faculty = isset($_POST['faculty']) ? (int) $_POST['faculty'] : 0;
+  $faculty_value = ($faculty > 0) ? $faculty : 'NULL';
 
   if ($manual_id == 0) {
     // Generate a unique verification code
@@ -61,10 +63,10 @@ if (isset($_POST['close_manual'])) {
       $manual_code = generateVerificationCode(8);
     }
 
-    mysqli_query($conn, "INSERT INTO manuals (title,	course_code,	price, dept,	code,	due_date,	quantity,	user_id, school_id) 
-        VALUES ('$title',	'$course_code',	$price, $user_dept,	'$manual_code',	'$due_date',	$quantity,	$user_id, $school_id)");
+    mysqli_query($conn, "INSERT INTO manuals (title,	course_code,	price, dept,	faculty,	code,	due_date,	quantity,	user_id, school_id) 
+        VALUES ('$title',	'$course_code',	$price, $user_dept,	$faculty_value,	'$manual_code',	'$due_date',	$quantity,	$user_id, $school_id)");
   } else {
-    mysqli_query($conn, "UPDATE manuals SET title = '$title', course_code = '$course_code', price = $price, due_date = '$due_date', quantity = $quantity 
+    mysqli_query($conn, "UPDATE manuals SET title = '$title', course_code = '$course_code', price = $price, due_date = '$due_date', quantity = $quantity, faculty = $faculty_value 
         WHERE id = $manual_id");
   }
 

--- a/admin/user.php
+++ b/admin/user.php
@@ -59,6 +59,15 @@ function getBankName($code, $bankList)
 
 // Get the bank name based on the bank code
 $bankName = getBankName($bank, $bankList);
+
+$faculties = [];
+if ($_SESSION['nivas_userRole'] == 'hoc') {
+  $faculties_query = mysqli_query($conn, "SELECT id, name FROM faculties WHERE school_id = $school_id AND status = 'active' ORDER BY name ASC");
+
+  while ($faculty = mysqli_fetch_assoc($faculties_query)) {
+    $faculties[$faculty['id']] = $faculty['name'];
+  }
+}
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -600,6 +609,15 @@ $bankName = getBankName($bank, $bankList);
                           <div class="form-outline mb-4">
                             <input type="text" name="title" class="form-control form-control-lg w-100" required="">
                             <label class="form-label" for="title">Manual Title</label>
+                          </div>
+                          <div class="form-group mb-4">
+                            <label class="form-check-label mb-0" for="manual_faculty">Associated Faculty</label><br />
+                            <select id="manual_faculty" name="faculty" class="form-select form-select-lg" <?php echo empty($faculties) ? 'disabled' : 'required'; ?>>
+                              <option value="" selected disabled><?php echo empty($faculties) ? 'No faculties available' : 'Select faculty'; ?></option>
+                              <?php foreach ($faculties as $faculty_id => $faculty_name): ?>
+                                <option value="<?php echo (int) $faculty_id; ?>"><?php echo htmlspecialchars($faculty_name); ?></option>
+                              <?php endforeach; ?>
+                            </select>
                           </div>
                           <div class="row">
                             <div class="col-md-6">

--- a/admin/user.php
+++ b/admin/user.php
@@ -92,6 +92,10 @@ if ($_SESSION['nivas_userRole'] == 'hoc') {
   <link rel="stylesheet" href="../assets/css/dashboard/style.css">
   <!-- endinject -->
   <style>
+    .manual-faculty-select {
+      width: 100%;
+    }
+
     .manual-faculty-select:focus {
       border-color: var(--bs-primary, #FF9100);
       box-shadow: 0 0 0 0.25rem rgba(255, 145, 0, 0.25);

--- a/admin/user.php
+++ b/admin/user.php
@@ -662,6 +662,7 @@ if ($_SESSION['nivas_userRole'] == 'hoc') {
                                 <option value="<?php echo (int) $faculty_id; ?>"><?php echo htmlspecialchars($faculty_name); ?></option>
                               <?php endforeach; ?>
                             </select>
+                            <p class="form-text mt-2">This doesn't mean your faculty/college, but where the material is being collected from</p>
                           </div>
                         </div>
                         <div class="modal-footer">

--- a/admin/user.php
+++ b/admin/user.php
@@ -91,6 +91,13 @@ if ($_SESSION['nivas_userRole'] == 'hoc') {
   <!-- inject:css -->
   <link rel="stylesheet" href="../assets/css/dashboard/style.css">
   <!-- endinject -->
+  <style>
+    .manual-faculty-select:focus {
+      border-color: var(--bs-primary, #FF9100);
+      box-shadow: 0 0 0 0.25rem rgba(255, 145, 0, 0.25);
+      outline: 0;
+    }
+  </style>
 
   <!-- Google Sign-In API library -->
   <script src="https://accounts.google.com/gsi/client" async defer></script>
@@ -610,15 +617,6 @@ if ($_SESSION['nivas_userRole'] == 'hoc') {
                             <input type="text" name="title" class="form-control form-control-lg w-100" required="">
                             <label class="form-label" for="title">Manual Title</label>
                           </div>
-                          <div class="form-group mb-4">
-                            <label class="form-check-label mb-0" for="manual_faculty">Associated Faculty</label><br />
-                            <select id="manual_faculty" name="faculty" class="form-select form-select-lg" <?php echo empty($faculties) ? 'disabled' : 'required'; ?>>
-                              <option value="" selected disabled><?php echo empty($faculties) ? 'No faculties available' : 'Select faculty'; ?></option>
-                              <?php foreach ($faculties as $faculty_id => $faculty_name): ?>
-                                <option value="<?php echo (int) $faculty_id; ?>"><?php echo htmlspecialchars($faculty_name); ?></option>
-                              <?php endforeach; ?>
-                            </select>
-                          </div>
                           <div class="row">
                             <div class="col-md-6">
                               <div class="form-outline mb-4">
@@ -650,6 +648,16 @@ if ($_SESSION['nivas_userRole'] == 'hoc') {
                                 <label class="form-label" for="due_date">Due Date</label>
                               </div>
                             </div>
+                          </div>
+                          <div class="form-group mb-0">
+                            <label class="form-label" for="manual_faculty">Associated Faculty</label>
+                            <select id="manual_faculty" name="faculty"
+                              class="form-control form-control-lg manual-faculty-select" <?php echo empty($faculties) ? 'disabled' : 'required'; ?>>
+                              <option value="" selected disabled><?php echo empty($faculties) ? 'No faculties available' : 'Select faculty'; ?></option>
+                              <?php foreach ($faculties as $faculty_id => $faculty_name): ?>
+                                <option value="<?php echo (int) $faculty_id; ?>"><?php echo htmlspecialchars($faculty_name); ?></option>
+                              <?php endforeach; ?>
+                            </select>
                           </div>
                         </div>
                         <div class="modal-footer">

--- a/sql/niverpay_db.sql
+++ b/sql/niverpay_db.sql
@@ -169,6 +169,7 @@ CREATE TABLE `manuals` (
   `due_date` datetime NOT NULL,
   `quantity` int(11) NOT NULL,
   `dept` int(11) NOT NULL,
+  `faculty` int(11) DEFAULT NULL,
   `user_id` int(11) NOT NULL,
   `currency` varchar(30) NOT NULL DEFAULT 'NGN',
   `school_id` int(11) NOT NULL DEFAULT 1,


### PR DESCRIPTION
## Summary
- load faculties for HOC users and expose an associated faculty dropdown in the manual creation/editing modals
- show the chosen faculty within the materials table and prepopulate the modal when editing a manual
- persist the new faculty attribute for manuals and document the schema change

## Testing
- php -l admin/index.php
- php -l admin/user.php
- php -l admin/model/manuals.php

------
https://chatgpt.com/codex/tasks/task_e_68f5ec45a6f88328800ef7755cd90914